### PR TITLE
Support for SDV 1.5 and other fixes

### DIFF
--- a/DeluxeGrabber/manifest.json
+++ b/DeluxeGrabber/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
-   "Name": "Deluxe Auto-Grabber",
-   "Author": "stokastic",
-   "Version": "2.5.1",
-   "Description": "Allows use of autograbber for coops, crops, and forage",
-   "UniqueID": "stokastic.DeluxeGrabber",
-   "EntryDll": "DeluxeGrabber.dll",
-   "MinimumApiVersion": "3.0.0",
-   "UpdateKeys": [ "Nexus:2462" ]
+  "Name": "Deluxe Auto-Grabber",
+  "Author": "stokastic",
+  "Version": "2.5.3-unofficial.6-frogfrag.",
+  "Description": "Allows use of autograbber for coops, crops, and forage",
+  "UniqueID": "stokastic.DeluxeGrabber",
+  "EntryDll": "DeluxeGrabber.dll",
+  "MinimumApiVersion": "3.0.0",
+  "UpdateKeys": [ "Nexus:2462" ]
 }

--- a/DeluxeGrabber/manifest.json
+++ b/DeluxeGrabber/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Deluxe Auto-Grabber",
   "Author": "stokastic",
-  "Version": "2.5.3-unofficial.6-frogfrag.",
+  "Version": "2.5.1",
   "Description": "Allows use of autograbber for coops, crops, and forage",
   "UniqueID": "stokastic.DeluxeGrabber",
   "EntryDll": "DeluxeGrabber.dll",


### PR DESCRIPTION
Hi! I've made a proper update for Deluxe Auto-Grabber, with full support for 1.5, Ginger foraging and Golden Walnuts fixes and a few more things:

-Supports SDV 1.5.1, SMAPI 3.8.2
-Fixes Golden Walnuts issues by avoiding the collection of those
-Changes the Minimal harvest formula to allow a value higher than 1, up to the established Max value for the crop - increasing per Farmer Level
-Can grab Ginger - New 1.5 forage item